### PR TITLE
feat: Configurable font size/scale

### DIFF
--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -161,8 +161,8 @@ namespace Lamp {
 
                     Lamp::Core::FS::lampIO::saveKeyData("Colour_SearchHighlight", ((std::string)Lamp::Core::lampControl::getInstance().Colour_SearchHighlight), "LAMP CONFIG");
 
-					// I don't feel like doing the work to get the value properly, and this seems to work fine
-					Lamp::Core::FS::lampIO::saveKeyData("Font_Scale", std::to_string(io.FontGlobalScale), "LAMP CONFIG");
+                    // I don't feel like doing the work to get the value properly, and this seems to work fine
+                    Lamp::Core::FS::lampIO::saveKeyData("Font_Scale", std::to_string(io.FontGlobalScale), "LAMP CONFIG");
 
                     return true;
                 }

--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -76,6 +76,7 @@ namespace Lamp {
                     {ImGuiCol_SeparatorHovered,"Colour_SeparatorHover"}
             };
 
+			const float defaultFontScale = 1.0f;
 
             void getConfigColours(){
                 int x = 0;
@@ -141,6 +142,11 @@ namespace Lamp {
                 Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = ImVec4(lampColour::getInstance().floatMap[x][0],lampColour::getInstance().floatMap[x][1],lampColour::getInstance().floatMap[x][2],lampColour::getInstance().floatMap[x][3]);
 
 
+				// basically ripped from the demo, set a min/max value and adds a drag-bar thing to set/update the scale to that value
+				const float MIN_SCALE = 0.3f;
+				const float MAX_SCALE = 2.0f;
+				ImGuiIO& io = ImGui::GetIO();
+				ImGui::DragFloat("Font_Scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 
 
                 if(ImGui::Button("Save")){
@@ -154,6 +160,9 @@ namespace Lamp {
                     }
 
                     Lamp::Core::FS::lampIO::saveKeyData("Colour_SearchHighlight", ((std::string)Lamp::Core::lampControl::getInstance().Colour_SearchHighlight), "LAMP CONFIG");
+
+					// I don't feel like doing the work to get the value properly, and this seems to work fine
+					Lamp::Core::FS::lampIO::saveKeyData("Font_Scale", std::to_string(io.FontGlobalScale), "LAMP CONFIG");
 
                     return true;
                 }
@@ -175,6 +184,7 @@ namespace Lamp {
                     }
 
 
+					io.FontGlobalScale = lampColour::getInstance().defaultFontScale;
                 }
 
                 ImGui::End();

--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -76,7 +76,7 @@ namespace Lamp {
                     {ImGuiCol_SeparatorHovered,"Colour_SeparatorHover"}
             };
 
-			const float defaultFontScale = 1.0f;
+            const float defaultFontScale = 1.0f;
 
             void getConfigColours(){
                 int x = 0;
@@ -142,11 +142,11 @@ namespace Lamp {
                 Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = ImVec4(lampColour::getInstance().floatMap[x][0],lampColour::getInstance().floatMap[x][1],lampColour::getInstance().floatMap[x][2],lampColour::getInstance().floatMap[x][3]);
 
 
-				// basically ripped from the demo, set a min/max value and adds a drag-bar thing to set/update the scale to that value
-				const float MIN_SCALE = 0.3f;
-				const float MAX_SCALE = 2.0f;
-				ImGuiIO& io = ImGui::GetIO();
-				ImGui::DragFloat("Font_Scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+                // basically ripped from the demo, set a min/max value and adds a drag-bar thing to set/update the scale to that value
+                const float MIN_SCALE = 0.3f;
+                const float MAX_SCALE = 2.0f;
+                ImGuiIO& io = ImGui::GetIO();
+                ImGui::DragFloat("Font_Scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 
 
                 if(ImGui::Button("Save")){
@@ -184,7 +184,7 @@ namespace Lamp {
                     }
 
 
-					io.FontGlobalScale = lampColour::getInstance().defaultFontScale;
+                    io.FontGlobalScale = lampColour::getInstance().defaultFontScale;
                 }
 
                 ImGui::End();

--- a/main.cpp
+++ b/main.cpp
@@ -102,11 +102,11 @@ int main(int, char**)
 
     Lamp::Games::getInstance().currentProfile = Lamp::Games::getInstance().currentGame->KeyInfo()["CurrentProfile"];
 
-	// Try to load and set the global font scale. I am pretty sure this is not a good way of doing this...
-	std::string loadedFontScale = Lamp::Core::FS::lampIO::loadKeyData("Font_Scale", "LAMP CONFIG");
-	if(loadedFontScale != ""){
-		io.FontGlobalScale = std::stof(loadedFontScale);
-	}
+    // Try to load and set the global font scale. I am pretty sure this is not a good way of doing this...
+    std::string loadedFontScale = Lamp::Core::FS::lampIO::loadKeyData("Font_Scale", "LAMP CONFIG");
+    if(loadedFontScale != ""){
+        io.FontGlobalScale = std::stof(loadedFontScale);
+    }
 
     Lamp::Core::Base::lampLog::getInstance().log("Creating Directories");
     try {

--- a/main.cpp
+++ b/main.cpp
@@ -102,6 +102,11 @@ int main(int, char**)
 
     Lamp::Games::getInstance().currentProfile = Lamp::Games::getInstance().currentGame->KeyInfo()["CurrentProfile"];
 
+	// Try to load and set the global font scale. I am pretty sure this is not a good way of doing this...
+	std::string loadedFontScale = Lamp::Core::FS::lampIO::loadKeyData("Font_Scale", "LAMP CONFIG");
+	if(loadedFontScale != ""){
+		io.FontGlobalScale = std::stof(loadedFontScale);
+	}
 
     Lamp::Core::Base::lampLog::getInstance().log("Creating Directories");
     try {


### PR DESCRIPTION
Adds a field on the Customize Lamp page to allow users to scale the font size. The size gets saved to file with the other options and gets loaded/applied on application start.
This should also reset to the original scale when the reset button is pressed.

I think the ideal solution would be to change the actual font-size instead of changing the font scale (scaling can make things blurry), but I was not sure how to accomplish that.