### PR TITLE
fix: Add missing return statements in lampConfig init

### DIFF
--- a/Lamp/Control/lampConfig.cpp
+++ b/Lamp/Control/lampConfig.cpp
@@ -19,9 +19,11 @@ bool Lamp::Core::lampConfig::init() {
             } else {
                 Base::lampLog::getInstance().log("Fatal. Cannot locate 7z.so", Base::lampLog::ERROR, true,
                                                  Base::lampLog::LMP_NO7ZP);
+                return false;
             }
         }
 
+    return true;
 }
 
 ImGuiWindowFlags Lamp::Core::lampConfig::DefaultWindowFlags() {


### PR DESCRIPTION
This fixes a fatal error that I have been encountering that occurs just at the end of the Lamp initialization.

When running a fresh build off of master (both at 436da0dd27e9340580f7220154a47be7f7cb31a8 and currently at a50bc1cc1b4a63ebbe0f705fa2d6607aeb7f18c5), the application would crash at this point:

```
[LAMP:LOG:0] Loading C77:installPath
[LAMP:WARNING:9] Unable to load C77:installPath
[LAMP:ERROR:7] Could not load modlist.
[LAMP:LOG:0] Loading LAMP CONFIG:showIntroMenu
[LAMP:WARNING:9] Unable to load LAMP CONFIG:showIntroMenu
[LAMP:LOG:0] Loading LAMP CONFIG:bit7zLibaryLocation
[LAMP:LOG:0] Initializing Lamp
Illegal instruction (core dumped)
```

I believe there is a chance that this fixes the issue that was encountered in #57, but, since there is a slight difference in where it crashes for them, that issue may be for something else.