### PR TITLE
fix: Re-enable deleting mod files with delete button and hide button on enabled mods

### DIFF
--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -335,7 +335,11 @@ namespace Lamp::Core{
                             }
                         } else{
                             if (ImGui::Button(("Delete Mod##" + std::to_string(i)).c_str())) {
-                                //std::remove(absolute(path).c_str());
+                                int deleteResult = std::remove(absolute(path).c_str());
+                                if(deleteResult != 0){
+                                    std::cout << "Error deleting file: " << absolute(path).c_str() << "\n   Error msg: " << strerror(errno) << "\n";
+                                }
+
                                 std::cout << absolute(path).c_str() << std::endl;
                                 ModList.erase(it);
                                 Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList,Games::getInstance().currentProfile);

--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -328,12 +328,19 @@ namespace Lamp::Core{
                         }
 
 
-                        if (ImGui::Button(("Delete Mod##" + std::to_string(i)).c_str())) {
-                            //std::remove(absolute(path).c_str());
-                            std::cout << absolute(path).c_str() << std::endl;
-                            ModList.erase(it);
-                            Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList,Games::getInstance().currentProfile);
-                            break;
+                        if((*it)->enabled) {
+                            ImGui::Text("Disabled"); //column placeholder
+                            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                                ImGui::SetTooltip("Only disabled mods can be deleted.");
+                            }
+                        } else{
+                            if (ImGui::Button(("Delete Mod##" + std::to_string(i)).c_str())) {
+                                //std::remove(absolute(path).c_str());
+                                std::cout << absolute(path).c_str() << std::endl;
+                                ModList.erase(it);
+                                Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList,Games::getInstance().currentProfile);
+                                break;
+                            }
                         }
 
 


### PR DESCRIPTION
This re-enables deleting the managed mod files when the delete button is clicked, which would be the expected behavior.

I also hid the delete button when a mod is enabled to prevent any issues from deleting an active/enabled/deployed mod.