### PR TITLE
feat: Add configuration for disabling automatic update check and add a a button for manual checks

### DIFF
--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -79,6 +79,8 @@ namespace Lamp {
             };
 
             const float defaultFontScale = 1.0f;
+            const bool defaultCheckForUpdateAtStart = true;
+            bool checkForUpdatesAtStartup = true;
 
             void getConfigColours(){
                 int x = 0;
@@ -133,6 +135,10 @@ namespace Lamp {
                 lampColour::getInstance().floatMap[x][2] = ((ImVec4)Lamp::Core::lampControl::getInstance().Colour_ButtonAlt).z;
                 lampColour::getInstance().floatMap[x][3] = ((ImVec4)Lamp::Core::lampControl::getInstance().Colour_ButtonAlt).w;
 
+                std::string loadedCheckUpdates = Lamp::Core::FS::lampIO::loadKeyData("Check_Updates_Startup", "LAMP CONFIG");
+                if(loadedCheckUpdates == "0" || loadedCheckUpdates == "false"){
+                    lampColour::getInstance().checkForUpdatesAtStartup = false;
+                }
             }
 
             void setColourTemp(ImGuiCol_ StylePoint, Lamp::Core::Base::lampTypes::lampHexAlpha colour){
@@ -167,6 +173,8 @@ namespace Lamp {
                 ImGuiIO& io = ImGui::GetIO();
                 ImGui::DragFloat("Font_Scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 
+                ImGui::Checkbox("Check for updates at startup (Check_Updates_Startup)", &lampColour::getInstance().checkForUpdatesAtStartup);
+
 
                 if(ImGui::Button("Save")){
                     ImGui::End();
@@ -183,6 +191,7 @@ namespace Lamp {
 
                     // I don't feel like doing the work to get the value properly, and this seems to work fine
                     Lamp::Core::FS::lampIO::saveKeyData("Font_Scale", std::to_string(io.FontGlobalScale), "LAMP CONFIG");
+                    Lamp::Core::FS::lampIO::saveKeyData("Check_Updates_Startup", std::to_string(lampColour::getInstance().checkForUpdatesAtStartup), "LAMP CONFIG");
 
                     return true;
                 }
@@ -206,6 +215,7 @@ namespace Lamp {
 
 
                     io.FontGlobalScale = lampColour::getInstance().defaultFontScale;
+                    lampColour::getInstance().checkForUpdatesAtStartup = lampColour::getInstance().defaultCheckForUpdateAtStart;
                 }
 
                 ImGui::End();

--- a/Lamp/Menu/lampMenu.cpp
+++ b/Lamp/Menu/lampMenu.cpp
@@ -294,6 +294,10 @@ void Lamp::Core::lampMenu::DefaultMenuBar() {
                 ImGui::EndMenu();
             }
 
+            if (ImGui::MenuItem("Check for Updates")) {
+                Lamp::Core::FS::lampUpdate::getInstance().checkForUpdates();
+            }
+
             ImGui::EndMenu();
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -92,7 +92,15 @@ int main(int, char**)
     Lamp::Core::Base::lampLog::getInstance().log(Lamp::Core::lampControl::getFormattedTimeAndDate()+" | | Battle Control Online, Welcome Back Commander.", Lamp::Core::Base::lampLog::LOG);
 
     Lamp::Games::getInstance();
-    Lamp::Core::FS::lampUpdate::getInstance().checkForUpdates();
+
+    std::string loadedCheckUpdates = Lamp::Core::FS::lampIO::loadKeyData("Check_Updates_Startup", "LAMP CONFIG");
+    bool checkForUpdates = true;
+    if(loadedCheckUpdates == "0" || loadedCheckUpdates == "false"){
+        checkForUpdates = false;
+    }
+    if(checkForUpdates){
+        Lamp::Core::FS::lampUpdate::getInstance().checkForUpdates();
+    }
     Lamp::Core::lampConfig::getInstance().lampFlags["showIntroMenu"]=(std::string)Lamp::Core::FS::lampIO::loadKeyData("showIntroMenu","LAMP CONFIG").returnReason;
     Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation = (std::string)Lamp::Core::FS::lampIO::loadKeyData("bit7zLibaryLocation","LAMP CONFIG").returnReason;
     Lamp::Core::lampConfig::getInstance().init();


### PR DESCRIPTION
Added an option to disable the automatic check for updates when the application starts. This also add and item to the menu to manually check for updates.

By default, the stored value in the configuration file would be a 1 or 0, but the checks would also support "false" as a valid value to turn it off. If the value in the configuration is not 0 or "false", then we assume that it is set to true, and do the update check.

I wasn't sure if this is something you would want to include, but figured I would make a pull request in case you don't mind having it. For some users (such as myself), this removes (what I would consider) unnecessary network traffic. I haven't tested this, but it could also technically provide a slight improvement in the startup time when disabled, as this check was done prior to displaying the UI.