### PR TITLE
feat: Highlight mods on hover

### DIFF
--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -306,9 +306,6 @@ namespace Lamp::Core{
                         if(lampConfig::getInstance().listHighlight == i) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, lampControl::getInstance().Colour_SearchHighlight);
                         }
-                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
-                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
-                        }
 
 
                         if(ImGui::Button(("Up##"+std::to_string(i)).c_str())){
@@ -365,6 +362,10 @@ namespace Lamp::Core{
                             ImGui::TableNextColumn();
                             if (ImGui::Button(ittt->first.c_str()))
                                 ittt->second = reinterpret_cast<bool *>(!ittt->second);
+
+                            if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                                ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                            }
                         }
 
                         ImGui::TableNextRow();

--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -210,6 +210,9 @@ namespace Lamp::Core{
                                 Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
                             }
                         }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
                         ImGui::TableNextColumn();
                         if(lampConfig::getInstance().listHighlight == i) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg,lampControl::getInstance().Colour_SearchHighlight);
@@ -227,6 +230,9 @@ namespace Lamp::Core{
                         ImGui::Text(cutname.c_str());
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
                             ImGui::SetTooltip((*it)->ArchivePath);
+                        }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                         }
 
                         // start drag and drop handling
@@ -300,18 +306,30 @@ namespace Lamp::Core{
                         if(lampConfig::getInstance().listHighlight == i) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, lampControl::getInstance().Colour_SearchHighlight);
                         }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
 
 
                         if(ImGui::Button(("Up##"+std::to_string(i)).c_str())){
                             moveUp(it);
                             Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
                         }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
                         ImGui::SameLine();
                         ImGui::Text((std::to_string(i)).c_str());
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
                         ImGui::SameLine();
                         if(ImGui::Button(("Down##"+std::to_string(i)).c_str())){
                             moveDown(it);
                             Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
+                        }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                         }
 
                         ImGui::TableNextColumn();
@@ -321,6 +339,9 @@ namespace Lamp::Core{
 
 
                         ImGui::Text((*it)->timeOfUpdate);
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
 
                         ImGui::TableNextColumn();
                         if(lampConfig::getInstance().listHighlight == i) {
@@ -334,6 +355,9 @@ namespace Lamp::Core{
                             ModList.erase(it);
                             Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList,Games::getInstance().currentProfile);
                             break;
+                        }
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
+                            ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                         }
 
 


### PR DESCRIPTION
This change attempts to highlight the mod row when you hover over it. Right now, it uses `Colour_SearchHighlight` for the highlight color.

There are some issues with how this currently works, but I have not figured out a way to make it work better. Right now, I have it checking for if the user is hovering over each item in the row individually, and applying the highlighting to the whole row if they are. This adds some messiness to the code that I am not a fan of (I feel like there *should* be some way to check if the user is hovering over the row or any children in a single check, rather than having to check after each item). This also means that the highlight effect gets dropped as you move between elements (for example, if you have a short mod name, the highlight goes away as you move between the mod name and the mod type).

I do not attempt to apply the highlight when hovering over the mod type, as that gets interrupted by the type selection menu anyway.

This should also apply the hover for any additional buttons added through the `ExtraOptions`, but this has not been tested as I am not really sure how to add those.