### PR TITLE
fix: Fixed inconsistent colors between init and reset

### DIFF
--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -39,11 +39,12 @@ namespace Lamp {
                     "590202-ff",
                     "4296f9-ff",
                     "a61103-ff",
-                    "1966bf-c6",
+                    "1966bf-c6", // Colour_SearchHighlight
+					//"a61103-ff",
                     "179642-ff" // green-ish color for ButtonAlt
             };
 
-            float floatMap[16][4] = {
+            float floatMap[15][4] = {
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f },
@@ -57,8 +58,8 @@ namespace Lamp {
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f },
-                    { 1.0f, 0.0f, 0.0f, 0.0f },
-                    { 1.0f, 0.0f, 0.0f, 0.0f },
+                    { 1.0f, 0.0f, 0.0f, 0.0f }, // Colour_SearchHighlight
+                    //{ 1.0f, 0.0f, 0.0f, 0.0f },
                     { 0.0f, 1.0f, 0.0f, 0.0f } // ButtonAlt
             };
 

--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -40,8 +40,7 @@ namespace Lamp {
                     "4296f9-ff",
                     "a61103-ff",
                     "1966bf-c6", // Colour_SearchHighlight
-					//"a61103-ff",
-                    "179642-ff" // green-ish color for ButtonAlt
+                    "1a994d-ff" // green-ish color for ButtonAlt
             };
 
             float floatMap[15][4] = {
@@ -59,7 +58,6 @@ namespace Lamp {
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f },
                     { 1.0f, 0.0f, 0.0f, 0.0f }, // Colour_SearchHighlight
-                    //{ 1.0f, 0.0f, 0.0f, 0.0f },
                     { 0.0f, 1.0f, 0.0f, 0.0f } // ButtonAlt
             };
 

--- a/Lamp/Menu/lampColour.h
+++ b/Lamp/Menu/lampColour.h
@@ -107,7 +107,7 @@ namespace Lamp {
 
                 std::string xloaded = Lamp::Core::FS::lampIO::loadKeyData("Colour_SearchHighlight", "LAMP CONFIG");
                 if(xloaded == ""){
-                    Lamp::Core::Base::lampTypes::lampHexAlpha colour("a61103-ff");
+                    Lamp::Core::Base::lampTypes::lampHexAlpha colour(lampColour::getInstance().defaultColours[x]);
                     Lamp::Core::FS::lampIO::saveKeyData("Colour_SearchHighlight", ((std::string)colour), "LAMP CONFIG");
                 }else{
                     Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = Lamp::Core::Base::lampTypes::lampHexAlpha(xloaded);
@@ -194,7 +194,7 @@ namespace Lamp {
                 }
                 ImGui::SameLine();
                 if(ImGui::Button("Reset")){
-                    Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = Lamp::Core::Base::lampTypes::lampHexAlpha("a61103-ff");
+                    Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = Lamp::Core::Base::lampTypes::lampHexAlpha(lampColour::getInstance().defaultColours[13]);
                     Lamp::Core::lampControl::getInstance().Colour_ButtonAlt = Lamp::Core::Base::lampTypes::lampHexAlpha(lampColour::getInstance().defaultColours[14]);
 
                     for (int i = 0; i < lampColour::getInstance().defaultColours.size(); ++i) {

--- a/main.cpp
+++ b/main.cpp
@@ -63,22 +63,21 @@ int main(int, char**)
 
 
 
-    Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = Lamp::Core::Base::lampTypes::lampHexAlpha("a61103-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_Text] = Lamp::Core::Base::lampTypes::lampHexAlpha("ffffff-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_WindowBg] = Lamp::Core::Base::lampTypes::lampHexAlpha("0a0d12-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_PopupBg] = Lamp::Core::Base::lampTypes::lampHexAlpha("141414-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_FrameBg] = Lamp::Core::Base::lampTypes::lampHexAlpha("260101-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_MenuBarBg] = Lamp::Core::Base::lampTypes::lampHexAlpha("071216-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_Button] = Lamp::Core::Base::lampTypes::lampHexAlpha("590202-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha("a61103-ff");
+    Lamp::Core::lampControl::getInstance().Colour_SearchHighlight = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[13]);
+    ImGui::GetStyle().Colors[ImGuiCol_Text] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[0]);
+    ImGui::GetStyle().Colors[ImGuiCol_WindowBg] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[1]);
+    ImGui::GetStyle().Colors[ImGuiCol_PopupBg] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[2]);
+    ImGui::GetStyle().Colors[ImGuiCol_FrameBg] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[3]);
+    ImGui::GetStyle().Colors[ImGuiCol_MenuBarBg] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[4]);
+    ImGui::GetStyle().Colors[ImGuiCol_Button] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[5]);
+    ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[6]);
+    ImGui::GetStyle().Colors[ImGuiCol_ButtonActive] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[7]);
 
-    ImGui::GetStyle().Colors[ImGuiCol_ButtonActive] = Lamp::Core::Base::lampTypes::lampHexAlpha("260101-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_Header] = Lamp::Core::Base::lampTypes::lampHexAlpha("4296f9-4f");
-    ImGui::GetStyle().Colors[ImGuiCol_HeaderHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha("4296f9-cc");
-    ImGui::GetStyle().Colors[ImGuiCol_HeaderActive] = Lamp::Core::Base::lampTypes::lampHexAlpha("590202-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_ButtonHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha("4296f9-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_Separator] = Lamp::Core::Base::lampTypes::lampHexAlpha("a61103-ff");
-    ImGui::GetStyle().Colors[ImGuiCol_SeparatorHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha("1966bf-c6");
+    ImGui::GetStyle().Colors[ImGuiCol_Header] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[8]);
+    ImGui::GetStyle().Colors[ImGuiCol_HeaderHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[9]);
+    ImGui::GetStyle().Colors[ImGuiCol_HeaderActive] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[10]);
+	ImGui::GetStyle().Colors[ImGuiCol_Separator] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[11]);
+    ImGui::GetStyle().Colors[ImGuiCol_SeparatorHovered] = Lamp::Core::Base::lampTypes::lampHexAlpha(Lamp::Core::lampColour::getInstance().defaultColours[12]);
 
     Lamp::Core::Base::lampLog::getInstance().log("Clearing log file.");
     const std::string filename = "lamp.log";


### PR DESCRIPTION
The initial colors loaded when the application has not yet been run (or when the config file is deleted) and the colors set when the reset button was clicked were different.

This should resolve that by removing an extra, unused default color declaration, and by referencing the default colors defined in `lampColours.h`, instead of having a separate set of values hard-coded in `main.cpp`.

I also made an extremely minor change to the "default" ButtonAlt color so that the RGB values do not change on reset.