### PR TITLE
fix: a crash that can happen when deleting mods

### DIFF
--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -340,6 +340,7 @@ namespace Lamp::Core{
                                 std::cout << absolute(path).c_str() << std::endl;
                                 ModList.erase(it);
                                 Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList,Games::getInstance().currentProfile);
+                                ImGui::EndDisabled(); // fixes a crash when deleting items (when at least 1 mod has been enabled)
                                 break;
                             }
 


### PR DESCRIPTION
This should fix a crash that could happen when deleting mods, which seems to have been introduced with the disabled button change in 65c0c4241a4906884b1fb1265b7bebf0d96da6a8.

I did not fully explore the cause, but it seemed like the crash would occur when you had at least 1 mod enabled and deleted another mod. I believe this was because we begin a disabled section (`BeginDisabled`), but we do not properly close out that section when a mod is deleted.