### PR TITLE
feat: Add mod filename checks to prevent adding duplicate mods

### DIFF
--- a/game-data/BG3/BG3.cpp
+++ b/game-data/BG3/BG3.cpp
@@ -9,34 +9,36 @@
 
 Lamp::Game::lampReturn Lamp::Game::BG3::registerArchive(Lamp::Game::lampString Path) {
 
-//    for (Core::Base::lampMod::Mod* it : ModList) {
-//
-//        std::filesystem::path NewFilePath = Path;
-//        std::filesystem::path TestingAgainstPath = it->ArchivePath;
-//
-//
-//        std::string NewFilePathCut = NewFilePath.filename();
-//        size_t posA = NewFilePathCut.find('-');
-//        if (posA != std::string::npos) {
-//            NewFilePathCut.erase(posA);
-//        }
-//
-//        std::string TestingAgainstPathCut = TestingAgainstPath.filename();
-//        size_t posB = TestingAgainstPathCut.find('-');
-//        if (posB != std::string::npos) {
-//            TestingAgainstPathCut.erase(posB);
-//        }
-//
-//
-//        if(NewFilePathCut == TestingAgainstPathCut){
-//
-//            it->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();
-//            it->ArchivePath = Path;
-//            return Lamp::Core::FS::lampIO::saveModList(Ident().ShortHand,ModList,Games::getInstance().currentProfile);
-//        }
-//
-//
-//    }
+    for (Core::Base::lampMod::Mod* it : ModList) {
+
+        std::filesystem::path NewFilePath = Path;
+        std::filesystem::path TestingAgainstPath = it->ArchivePath;
+
+
+        std::string NewFilePathCut = NewFilePath.filename();
+		/*
+        size_t posA = NewFilePathCut.find('-');
+        if (posA != std::string::npos) {
+            NewFilePathCut.erase(posA);
+        }
+		*/
+
+        std::string TestingAgainstPathCut = TestingAgainstPath.filename();
+        size_t posB = TestingAgainstPathCut.find('/');
+        if (posB != std::string::npos) {
+            TestingAgainstPathCut.erase(posB);
+        }
+
+
+        if(NewFilePathCut == TestingAgainstPathCut){
+
+            it->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();
+            it->ArchivePath = Path;
+            return Lamp::Core::FS::lampIO::saveModList(Ident().ShortHand,ModList,Games::getInstance().currentProfile);
+        }
+
+
+    }
 
     Core::Base::lampMod::Mod  * newArchive = new Core::Base::lampMod::Mod{Path,ModType::NaN, false};
     newArchive->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();

--- a/game-data/C77/C77.cpp
+++ b/game-data/C77/C77.cpp
@@ -8,34 +8,36 @@ namespace Lamp {
     namespace Game {
         lampReturn C77::registerArchive(lampString Path) {
 
-//            for (Core::Base::lampMod::Mod* it : ModList) {
-//
-//                std::filesystem::path NewFilePath = Path;
-//                std::filesystem::path TestingAgainstPath = it->ArchivePath;
-//
-//
-//                std::string NewFilePathCut = NewFilePath.filename();
-//                size_t posA = NewFilePathCut.find('-');
-//                if (posA != std::string::npos) {
-//                    NewFilePathCut.erase(posA);
-//                }
-//
-//                std::string TestingAgainstPathCut = TestingAgainstPath.filename();
-//                size_t posB = TestingAgainstPathCut.find('-');
-//                if (posB != std::string::npos) {
-//                    TestingAgainstPathCut.erase(posB);
-//                }
-//
-//
-//                if(NewFilePathCut == TestingAgainstPathCut){
-//
-//                    it->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();
-//                    it->ArchivePath = Path;
-//                    return Lamp::Core::FS::lampIO::saveModList(Ident().ShortHand,ModList,Games::getInstance().currentProfile);
-//                }
-//
-//
-//            }
+            for (Core::Base::lampMod::Mod* it : ModList) {
+
+                std::filesystem::path NewFilePath = Path;
+                std::filesystem::path TestingAgainstPath = it->ArchivePath;
+
+
+                std::string NewFilePathCut = NewFilePath.filename();
+                /*
+                size_t posA = NewFilePathCut.find('-');
+                if (posA != std::string::npos) {
+                    NewFilePathCut.erase(posA);
+                }
+                */
+
+                std::string TestingAgainstPathCut = TestingAgainstPath.filename();
+                size_t posB = TestingAgainstPathCut.find('/');
+                if (posB != std::string::npos) {
+                    TestingAgainstPathCut.erase(posB);
+                }
+
+
+                if(NewFilePathCut == TestingAgainstPathCut){
+
+                    it->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();
+                    it->ArchivePath = Path;
+                    return Lamp::Core::FS::lampIO::saveModList(Ident().ShortHand,ModList,Games::getInstance().currentProfile);
+                }
+
+
+            }
 
             Core::Base::lampMod::Mod  * newArchive = new Core::Base::lampMod::Mod{Path,ModType::C77_MOD, false};
             newArchive->timeOfUpdate = Lamp::Core::lampControl::getFormattedTimeAndDate();


### PR DESCRIPTION
This re-adds some file checking for adding files to BG3 and C77. It should compare the entire filename and make sure that the file is not already added.

While 6b5a8f2 did fix the issue in #78, I believe this change may provide some additional benefits by preventing duplicate files from being added. Having duplicate files could cause some unexpected behavior if you have multiple entries of a mod and delete any of those entries (while still keeping at least 1 entry for the mod).



