### PR TITLE
fix: Resolve minor compile warnings

### DIFF
--- a/Lamp/Base/lampBase.h
+++ b/Lamp/Base/lampBase.h
@@ -611,6 +611,7 @@ namespace Lamp::Core::Base{
                 }
                 break;
             }
+            return true;
         }
 
     private:

--- a/Lamp/Filesystem/lampExtract.cpp
+++ b/Lamp/Filesystem/lampExtract.cpp
@@ -49,7 +49,7 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
     else{
         return false;
     }
-
+    return false;
 }
 
 Lamp::Core::lampReturn Lamp::Core::FS::lampExtract::moveModSpecificFileType(const Lamp::Core::Base::lampMod::Mod *mod,

--- a/Lamp/Parse/lampParse.h
+++ b/Lamp/Parse/lampParse.h
@@ -384,7 +384,7 @@ namespace Lamp::Core::Parse{
                 }
             }
 
-
+            return false;
         }
 
     };

--- a/game-data/BG3/BG3.cpp
+++ b/game-data/BG3/BG3.cpp
@@ -413,7 +413,7 @@ Lamp::Game::lampReturn Lamp::Game::BG3::deployment() {
 }
 
 Lamp::Game::lampReturn Lamp::Game::BG3::postDeploymentTasks() {
-
+    return false;
 }
 
 void Lamp::Game::BG3::listArchives() {


### PR DESCRIPTION
This should get rid of some minor warnings that come up during compile.

These mostly seemed to be related to missing returns, when a boolean return value was expected from the function.