### PR TITLE
feat: Add context menu for moving mods to top or bottom

### DIFF
--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -147,6 +147,25 @@ namespace Lamp::Core{
                 ++it;
             }
 
+            /**
+             * @brief Moves an item to specific position in the mod list.
+             *
+             * @param it Iterator pointing to the item to move.
+             * @param position Integer position to move the item to.
+             */
+            void moveModTo(std::vector<Base::lampMod::Mod*>::iterator& it, int position) {
+                int currentPos = it - ModList.begin();
+                if(currentPos > position){
+                    for(int ind = currentPos; ind > position; ind--){
+                        moveUp(it);
+                    }
+                } else if(currentPos < position){
+                    for(int ind = currentPos; ind < position; ind++){
+                        moveDown(it);
+                    }
+                }
+            }
+
         public:
 
 
@@ -174,7 +193,7 @@ namespace Lamp::Core{
                 if (ImGui::InputTextWithHint("##searcher","Type here to search your mods...", lampConfig::getInstance().searchBuffer, 250)) {
                     lampConfig::getInstance().listHighlight = findClosestMatchPosition();
                 }
-				
+
                 ImGuiTableFlags mod_table_flags = 0;
                 mod_table_flags |= ImGuiTableFlags_SizingStretchProp;
                 mod_table_flags |= ImGuiTableFlags_Hideable; // allow hiding coumns via context menu
@@ -233,6 +252,17 @@ namespace Lamp::Core{
                         }
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
+                        }
+
+                        auto contextId = "MOD_NAME_CONTEXT_" + std::to_string(i);
+                        if (ImGui::BeginPopupContextItem(contextId.c_str())){
+                            if(ImGui::Selectable("Move to top")){
+                                moveModTo(it, 0);
+                            }
+                            if(ImGui::Selectable("Move to bottom")){
+                                moveModTo(it, std::distance(ModList.begin(), ModList.end()));
+                            }
+                            ImGui::EndPopup();
                         }
 
                         // start drag and drop handling
@@ -367,7 +397,7 @@ namespace Lamp::Core{
                             if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
                                 ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                             }
-                      
+
                             ImGui::EndDisabled();
 
 

--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -206,7 +206,6 @@ namespace Lamp::Core{
 					ImGui::TableHeadersRow();
                     ImGui::TableNextRow();
 
-                    int dnd_move_from = -1, dnd_move_to = -1; // initialize position tracking vars for drag and drop functionality
                     int i = 0;
                     for (auto it = ModList.begin(); it != ModList.end(); ++it) {
 
@@ -286,24 +285,8 @@ namespace Lamp::Core{
                             target_flags |= ImGuiDragDropFlags_SourceAllowNullID;
                             if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("MODLIST_DND", target_flags))
                             {
-                                dnd_move_from = *(const int*)payload->Data;
-                                dnd_move_to = i;
-
-                                auto* tmp = ModList[dnd_move_from];
-                                // update the ModList (this also seems to update the UI immediately)
-                                if(dnd_move_from > dnd_move_to){
-                                    // if moving a mod to a higher position, shift things down and then place the moved mod
-                                    for(int ind = dnd_move_from; ind > dnd_move_to; ind--){
-                                        ModList[ind] = ModList[ind - 1];
-                                    }
-                                } else{
-                                    // if moving a mod to a lower position, shift things up and then place the moved mod
-                                    for(int ind = dnd_move_from; ind < dnd_move_to; ind++){
-                                        ModList[ind] = ModList[ind + 1];
-                                    }
-                                }
-                                ModList[dnd_move_to] = tmp;
-
+                                auto movingMod = ModList.begin() + *(const int*)payload->Data; // get original position from the payload data
+                                moveModTo(movingMod, i);
                                 // save the change to the profile's Mod_List
                                 Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
                             }

--- a/Lamp/Control/lampControl.h
+++ b/Lamp/Control/lampControl.h
@@ -257,9 +257,11 @@ namespace Lamp::Core{
                         if (ImGui::BeginPopupContextItem(contextId.c_str())){
                             if(ImGui::Selectable("Move to top")){
                                 moveModTo(it, 0);
+                                Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
                             }
                             if(ImGui::Selectable("Move to bottom")){
                                 moveModTo(it, std::distance(ModList.begin(), ModList.end()));
+                                Core::FS::lampIO::saveModList(Lamp::Games::getInstance().currentGame->Ident().ShortHand, ModList, Games::getInstance().currentProfile);
                             }
                             ImGui::EndPopup();
                         }


### PR DESCRIPTION
This adds a context menu on the mod name with options to move the mod to the top or bottom of the load order.

This should help with moving mods around on larger mod lists.

I also modified how the drag and drop moves mods to use the new `moveModTo` function I added. I think this simplifies the logic visually on top of using the other existing functions for moving mods instead of relying on something custom.