### PR TITLE
feat: Add quit button to the menu

### DIFF
--- a/Lamp/Menu/lampMenu.cpp
+++ b/Lamp/Menu/lampMenu.cpp
@@ -312,7 +312,6 @@ void Lamp::Core::lampMenu::DefaultMenuBar() {
             }
 
 
-
             ImGui::EndMenu();
         }
 

--- a/Lamp/Menu/lampMenu.cpp
+++ b/Lamp/Menu/lampMenu.cpp
@@ -307,6 +307,10 @@ void Lamp::Core::lampMenu::DefaultMenuBar() {
                 ImGui::EndMenu();
             }
 
+            if (ImGui::MenuItem("Quit")) {
+                this->userRequestedQuit = true;
+            }
+
 
 
             ImGui::EndMenu();

--- a/Lamp/Menu/lampMenu.h
+++ b/Lamp/Menu/lampMenu.h
@@ -20,6 +20,7 @@ namespace Lamp::Core{
         };
 
         Menus currentMenu = LICENCE_MENU;
+        bool userRequestedQuit = false;
 
         void RunMenus();
 

--- a/main.cpp
+++ b/main.cpp
@@ -145,7 +145,7 @@ int main(int, char**)
     Lamp::Core::lampCustomise::getInstance().getConfigColours();
 
     bool done = false;
-    while (!done && !Menus.userRequestedQuit)
+    while (!done)
     {
         SDL_Event event;
         while (SDL_PollEvent(&event))
@@ -177,6 +177,10 @@ int main(int, char**)
         SDL_RenderClear(renderer);
         ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData());
         SDL_RenderPresent(renderer);
+
+        if(Menus.userRequestedQuit){
+            done = true;
+        }
     }
 
     ImGui_ImplSDLRenderer2_Shutdown();

--- a/main.cpp
+++ b/main.cpp
@@ -145,7 +145,7 @@ int main(int, char**)
     Lamp::Core::lampCustomise::getInstance().getConfigColours();
 
     bool done = false;
-    while (!done)
+    while (!done && !Menus.userRequestedQuit)
     {
         SDL_Event event;
         while (SDL_PollEvent(&event))


### PR DESCRIPTION
Adds a quit button to the main menu.

This option may feel nicer to some users over requiring the use of the close button on the window.

I was hoping for a somewhat 'cleaner' way of doing this (such as by manually triggering an `SDL_QUIT` event from the menu), but I have not yet figured out if that is possible. If you have a better way of handling this, feel free to close this PR or let me know. Otherwise, I believe this should work fine.