### PR TITLE
fix: Fix installing REDMod into the /mods directory

### DIFF
--- a/game-data/C77/C77.cpp
+++ b/game-data/C77/C77.cpp
@@ -130,6 +130,7 @@ namespace Lamp {
                         Lamp::Core::FS::lampExtract::moveModSpecificFolder(item,"bin","Cyberpunk 2777/bin");
                         Lamp::Core::FS::lampExtract::moveModSpecificFolder(item,"engine","Cyberpunk 2777/engine");
                         Lamp::Core::FS::lampExtract::moveModSpecificFolder(item,"REDMod","Cyberpunk 2777/REDMod");
+                        Lamp::Core::FS::lampExtract::moveModSpecificFolder(item,"mods","Cyberpunk 2777/mods");
 
                         Lamp::Core::lampControl::getInstance().deplopmentTracker.first++;
                     }


### PR DESCRIPTION
From what I have seen, REDMods typically want to be installed in `/mods` (as opposed to `/REDMod`). This should fix allowing them to install in the `/mods` directory.

I am basing this on what I see in mods like <https://www.nexusmods.com/cyberpunk2077/mods/5266> and <https://www.nexusmods.com/cyberpunk2077/mods/11479>. I have left the previous `/REDMod`, as I am unsure if some mods might need to install files there.