### PR TITLE
fix: Display full separator name when slashes are used

### DIFF
--- a/Lampray/Control/lampControl.h
+++ b/Lampray/Control/lampControl.h
@@ -263,6 +263,10 @@ namespace Lamp::Core{
                                 cutname.erase(pos);
                             }
                         }
+                        // use full path string for separators
+                        if((*it)->modType == Lamp::Games::getInstance().currentGame->SeparatorModType()){
+                            cutname = path.c_str();
+                        }
 
                         ImGui::Text(cutname.c_str());
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
@@ -505,6 +509,10 @@ namespace Lamp::Core{
 
                         std::filesystem::path path((*pendingDelete)->ArchivePath);
                         std::string delname = path.filename().c_str();
+                        // use full path string for separators
+                        if((*pendingDelete)->modType == Lamp::Games::getInstance().currentGame->SeparatorModType()){
+                            delname = path.c_str();
+                        }
 
                         std::string promptMessage = "Are you sure you want to delete: ";
                         promptMessage.append(delname);


### PR DESCRIPTION
This should fix an issue where a separator "name" would be truncated when slashes are used as part of the name.
