### PR TITLE
feat: Add default text for game path configuration buttons

### DIFF
--- a/Lampray/Control/lampControl.h
+++ b/Lampray/Control/lampControl.h
@@ -587,6 +587,12 @@ namespace Lamp::Core{
             void createImGuiMenu(){
                 ImGui::Text(displayString.c_str());
                 ImGui::Text(toolTip.c_str());
+
+                // set some default text to make the button more obvious when the path is not set (instead of just having small colored box that is not obviously clickable)
+                if(stringTarget == ""){
+                    stringTarget = (std::string) lampLang::LS("LAMPRAY_SELECT_PATH");
+                }
+
                 if(ImGui::Button((stringTarget+"##"+displayString).c_str())) {
                     nfdchar_t *outPath = NULL;
                     nfdresult_t result = NFD_PickFolder(NULL, &outPath);

--- a/Lampray/Lang/lampLang.h
+++ b/Lampray/Lang/lampLang.h
@@ -191,6 +191,7 @@ This action cannot be undone.)");
                 addLangNode("LAMPRAY_CUSTOM_COLOUR", "Colours");
                 addLangNode("LAMPRAY_CUSTOM_FONT", "Font Size");
                 addLangNode("LAMPRAY_CUSTOM_SV", "Save");
+                addLangNode("LAMPRAY_SELECT_PATH", "Select Path");
                 std::filesystem::create_directories("Lamp_Language/");
                 doc.save_file("Lamp_Language/English (UK).xml");
             }


### PR DESCRIPTION
This adds some text to the buttons for choosing the relevant game directories, which should make the buttons more obviously clickable for first-time users.