### PR TITLE
fix: Installed p7zip not found due to path being omitted

### DIFF
--- a/Lampray/Control/lampConfig.cpp
+++ b/Lampray/Control/lampConfig.cpp
@@ -14,6 +14,8 @@ bool Lamp::Core::lampConfig::init() {
                 bit7zLibaryLocation = "/usr/libexec/p7zip/7z.so";
             } else if (exists(std::filesystem::path{"/usr/lib/p7zip/7z.so"})) {
                 bit7zLibaryLocation = "/usr/lib/p7zip/7z.so";
+            } else if (exists(std::filesystem::path{"/usr/lib64/p7zip/7z.so"})) {
+                bit7zLibaryLocation = "/usr/lib64/p7zip/7z.so";
             } else if (exists(std::filesystem::path{"/usr/libexec/7z.so"})) {
                 bit7zLibaryLocation = "/usr/libexec/7z.so";
             } else {


### PR DESCRIPTION
Tested on 64-bit Mageia 9