### PR TITLE
build: add missing include statement in lampNotification.h

### DIFF
--- a/Lampray/Control/lampNotification.h
+++ b/Lampray/Control/lampNotification.h
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <algorithm>
 #include <string>
+#include <array>
 #include "../../third-party/imgui/imgui.h"
 
 


### PR DESCRIPTION
Without this include statement, both GCC and clang fails building, giving "incomplete type" errors.