### PR TITLE
build: Fix -Wformat warnings

### DIFF
--- a/Lampray/Base/lampBase.h
+++ b/Lampray/Base/lampBase.h
@@ -615,7 +615,7 @@ namespace Lamp::Core::Base{
 
                     ImGui::Begin(x, NULL, windowFlags);
 
-                    ImGui::Text(x);
+                    ImGui::Text("%s", x.c_str());
                     ImGui::Separator();
 
                     ImGui::Text("If an error persists please create an issue on GitHub.");

--- a/Lampray/Base/lampBase.h
+++ b/Lampray/Base/lampBase.h
@@ -171,6 +171,15 @@ namespace Lamp::Core::Base{
             bool as_bool() {
                 return (data == "1" || data == "true");
             }
+
+            /**
+             * @brief Get C string equivalent
+             *
+             * @return  A pointer to the c-string representation of the lampString object's value.
+             */
+            const char *c_str() const {
+                return static_cast<const char*>(*this);
+            }
         };
 
         /**

--- a/Lampray/Control/lampControl.h
+++ b/Lampray/Control/lampControl.h
@@ -269,9 +269,9 @@ namespace Lamp::Core{
                             cutname = path.c_str();
                         }
 
-                        ImGui::Text(cutname.c_str());
+                        ImGui::Text("%s", cutname.c_str());
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-                            ImGui::SetTooltip((*it)->ArchivePath);
+                            ImGui::SetTooltip("%s", (*it)->ArchivePath.c_str());
                         }
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
@@ -417,7 +417,7 @@ namespace Lamp::Core{
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                         }
                         ImGui::SameLine();
-                        ImGui::Text((std::to_string(i)).c_str());
+                        ImGui::Text("%s", (std::to_string(i)).c_str());
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
                         }
@@ -436,7 +436,7 @@ namespace Lamp::Core{
                         }
 
                         if((*it)->modType != Lamp::Games::getInstance().currentGame->SeparatorModType()) {
-                            ImGui::Text((*it)->timeOfUpdate);
+                            ImGui::Text("%s", (*it)->timeOfUpdate.c_str());
                         }
 
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
@@ -477,7 +477,7 @@ namespace Lamp::Core{
 
 
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && (*it)->enabled) {
-                            ImGui::SetTooltip(lampLang::LS("LAMPRAY_MODLIST_WARN"));
+                            ImGui::SetTooltip("%s", lampLang::LS("LAMPRAY_MODLIST_WARN").c_str());
                         }
                         if (ImGui::IsItemHovered(ImGuiHoveredFlags_None)) {
                             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0, lampControl::getInstance().Colour_SearchHighlight);
@@ -518,7 +518,7 @@ namespace Lamp::Core{
                         std::string promptMessage = lampLang::LS("LAMPRAY_MODLIST_WARN_SURE");
                         promptMessage.append(delname);
                         promptMessage.append((std::string)lampLang::LS("LAMPRAY_MODLIST_WARN_FINAL"));
-                        ImGui::Text(promptMessage.c_str());
+                        ImGui::Text("%s", promptMessage.c_str());
                         ImGui::Separator();
 
                         if (ImGui::Button(lampLang::LS("LAMPRAY_MODLIST_DELETE"), ImVec2(120, 0))) {
@@ -585,8 +585,8 @@ namespace Lamp::Core{
          * @brief Creates an ImGui menu for displaying game settings.
          */
             void createImGuiMenu(){
-                ImGui::Text(displayString.c_str());
-                ImGui::Text(toolTip.c_str());
+                ImGui::Text("%s", displayString.c_str());
+                ImGui::Text("%s", toolTip.c_str());
 
                 // set some default text to make the button more obvious when the path is not set (instead of just having small colored box that is not obviously clickable)
                 if(stringTarget == ""){

--- a/Lampray/Control/lampNotification.h
+++ b/Lampray/Control/lampNotification.h
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <algorithm>
 #include <string>
+#include <array>
 #include "../../third-party/imgui/imgui.h"
 
 

--- a/Lampray/Filesystem/lampUpdate.cpp
+++ b/Lampray/Filesystem/lampUpdate.cpp
@@ -51,6 +51,6 @@ void Lamp::Core::FS::lampUpdate::getExpression() {
             system(openCommand.c_str());
         }
     }else{
-        ImGui::Text(("v"+versionNumber).c_str());
+        ImGui::Text("%s", ("v"+versionNumber).c_str());
     }
 }

--- a/Lampray/Menu/lampMenu.cpp
+++ b/Lampray/Menu/lampMenu.cpp
@@ -16,8 +16,8 @@ void Lamp::Core::lampMenu::RunMenus() {
     ImGui::SetNextWindowPos(ImVec2(0, 0));
     if(Lamp::Core::lampControl::getInstance().inDeployment){
         ImGui::Begin("DEPLOYMENT", NULL, Lamp::Core::lampConfig::getInstance().DefaultWindowFlags());
-        ImGui::Text(Lamp::Core::lampControl::getInstance().deploymentStageTitle.c_str());
-        ImGui::Text((std::to_string(Lamp::Core::lampControl::getInstance().deplopmentTracker.first) + "/" + std::to_string(Lamp::Core::lampControl::getInstance().deplopmentTracker.second)).c_str());
+        ImGui::Text("%s", Lamp::Core::lampControl::getInstance().deploymentStageTitle.c_str());
+        ImGui::Text("%s", (std::to_string(Lamp::Core::lampControl::getInstance().deplopmentTracker.first) + "/" + std::to_string(Lamp::Core::lampControl::getInstance().deplopmentTracker.second)).c_str());
         ImGui::End();
     }else {
         switch (currentMenu) {
@@ -69,9 +69,9 @@ void Lamp::Core::lampMenu::IntroMenu() {
     size = ImGui::CalcTextSize(lampLang::LS("LAMPRAY_LONGNAME")).x + style.FramePadding.x * 2.0f;
     off = (avail - size) * 0.5f;
     if (off > 0.0f){ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);}
-    ImGui::Text(lampLang::LS("LAMPRAY_LONGNAME"));
+    ImGui::Text("%s", lampLang::LS("LAMPRAY_LONGNAME").c_str());
     ImGui::Separator();
-    ImGui::Text(lampLang::LS("LAMPRAY_LICENSE"));
+    ImGui::Text("%s", lampLang::LS("LAMPRAY_LICENSE").c_str());
 
 
 
@@ -97,7 +97,7 @@ void Lamp::Core::lampMenu::ModMenu() {
 
     float off = (avail - size) * 0.5f;
     if (off > 0.0f){ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);}
-    ImGui::Text(lampLang::LS("LAMPRAY_DRAGANDDROP"));
+    ImGui::Text("%s", lampLang::LS("LAMPRAY_DRAGANDDROP").c_str());
 
     size = ImGui::CalcTextSize(lampLang::LS("LAMPRAY_DEPLOY")).x + style.FramePadding.x * 2.0f;
     avail = ImGui::GetContentRegionAvail().x;
@@ -129,7 +129,7 @@ void Lamp::Core::lampMenu::ModMenu() {
         ImGui::SetNextWindowPos(ImVec2(0, 0));
 
         ImGui::Begin(lampLang::LS("LAMPRAY_CHECK"), NULL, Lamp::Core::lampConfig::getInstance().DefaultWindowFlags());
-        ImGui::Text(lampLang::LS("LAMPRAY_STARTTEXT"));
+        ImGui::Text("%s", lampLang::LS("LAMPRAY_STARTTEXT").c_str());
 
         if(ImGui::Button(lampLang::LS("LAMPRAY_START"))){
             deployCheck = !deployCheck;
@@ -344,7 +344,7 @@ void Lamp::Core::lampMenu::createProfileDialog() {
         }
 
 
-        ImGui::Text(lampLang::LS("LAMPRAY_PROFNM"));
+        ImGui::Text("%s", lampLang::LS("LAMPRAY_PROFNM").c_str());
         if(ImGui::InputText("##inputProf",profileBuffer,250, ImGuiInputTextFlags_EnterReturnsTrue) || ImGui::Button(lampLang::LS("LAMPRAY_PROFCRES"))){
             std::string pb(profileBuffer);
             Lamp::Core::Base::lampMod::Profile::addValue(Lamp::Games::getInstance().currentGame->KeyInfo()["ProfileList"],pb);


### PR DESCRIPTION
Some Linux distros uses `-Wformat -Werror=format-security` flags when
building C/C++ projects by default. This makes harder to build Lampray
on such distros with default build flags.