### PR TITLE
chore(ci): build and publish flatpak on release

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,144 @@
+---
+on:
+  pull_request:
+  issue_comment:
+    types: [created, edited, deleted]
+    
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: Release Management
+
+jobs:
+  ActorCheck:
+    runs-on: ubuntu-22.04
+    
+    outputs:
+      IsActionBot: ${{ steps.ActorCheck.outputs.IsActionBot }}
+      IsCommentEvent: ${{ steps.ActorCheck.outputs.IsCommentEvent }}
+      IsBuildCommentEvent: ${{ steps.ActorCheck.outputs.IsBuildCommentEvent }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: ActorCheck
+        id: ActorCheck
+        env:
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          EVENT: ${{ github.event_name }}
+          ISSUE_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Check if the actor is github-actions[bot]
+          # intial PRs created by the bot are ignored anyway
+          # but we don't want it recursing into itself
+          if [ "$ACTOR" = "github-actions[bot]" ]; then
+            echo "IsActionBot=true" >> $GITHUB_OUTPUT
+            echo "IsCommentEvent=false" >> $GITHUB_OUTPUT
+            echo "IsBuildCommentEvent=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "IsActionBot=false" >> $GITHUB_OUTPUT
+
+          # Check if the event is issue_comment 
+          if [ "$EVENT" != "issue_comment" ]; then
+            echo "IsCommentEvent=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "IsCommentEvent=true" >> $GITHUB_OUTPUT
+
+          # check if the issue body only contains the build command
+          if [ "$ISSUE_BODY" != "/build" ]; then
+            echo "IsBuildCommentEvent=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "IsBuildCommentEvent=true" >> $GITHUB_OUTPUT
+          
+
+  PrBuild:
+
+    needs: 
+      - ActorCheck
+
+    # only run if :
+    #  - a user commented /build
+    #  - a user made the pr
+    if: ${{ needs.ActorCheck.outputs.IsBuildCommentEvent == 'true' || (needs.ActorCheck.outputs.IsCommentEvent == 'false' && needs.ActorCheck.outputs.IsActionBot == 'false')  }}
+
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: OS Deps
+        uses: ./.github/actions/setup-os
+
+      - name: Tooling
+        uses: ./.github/actions/setup-tooling
+        with:
+          SetupCommand: ./setup.sh
+
+      - name: Build
+        run: |
+          ./build.sh Debug
+
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: lampray-pr-preview-binary
+          path: ./build/Lamp
+          
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Build output
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            A new [build is available][1] for testing :tada:
+
+              [1]: ${{ steps.artifact-upload.outputs.artifact-url}}
+
+  PrFlatPak:
+    needs:
+      - PrBuild
+    runs-on: ubuntu-22.04
+
+    container:
+      # gnome-45
+      # https://hub.docker.com/layers/bilelmoussaoui/flatpak-github-actions/gnome-45/images/sha256-16e884b42f6cfdbed3c2baaa3f2da621c7f4db25e53036b3b814ad0b67fcf5e2?context=explore
+      image: bilelmoussaoui/flatpak-github-actions@sha256:16e884b42f6cfdbed3c2baaa3f2da621c7f4db25e53036b3b814ad0b67fcf5e2
+      options: --privileged
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: lampray-pr-preview-binary
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: lampray.flatpak
+          manifest-path: org.github.chollingworth.Lampray.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: lampray-pr-preview-binary
+          path: ./build/Lamp

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,3 +1,4 @@
+---
 name: Check PR title
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:
@@ -83,4 +84,37 @@ jobs:
           else
             gh release upload ${RELEASE_TAG} ./build/Lampray#lamp-${RELEASE_TAG}
           fi
-          
+
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: lampray-release-binary
+          path: ./build/Lamp
+
+  FlatPak:
+    needs:
+      - ReleaseAutomation
+    runs-on: ubuntu-22.04
+
+    container:
+      # gnome-45
+      # https://hub.docker.com/layers/bilelmoussaoui/flatpak-github-actions/gnome-45/images/sha256-16e884b42f6cfdbed3c2baaa3f2da621c7f4db25e53036b3b814ad0b67fcf5e2?context=explore
+      image: bilelmoussaoui/flatpak-github-actions@sha256:16e884b42f6cfdbed3c2baaa3f2da621c7f4db25e53036b3b814ad0b67fcf5e2
+      options: --privileged
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: lampray-release-binary
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: lampray.flatpak
+          manifest-path: org.github.chollingworth.Lampray.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload
+        with:
+          name: lampray-release-binary
+          path: ./build/Lamp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ Push your changes to your forked repository.
 2. Fill in the pull request title with the following format
     1. for new features, `feat: your feature oneliner name`
     2. for bugfixes or minor changes: `fix: your bugfix oneline name`
-    3. for other kinds, see https://www.conventionalcommits.org/en/v1.0.0/#summary
+    3. for fixes or features to ci: `chore(ci): your ci change oneline name`
+    4. for other kinds, see https://www.conventionalcommits.org/en/v1.0.0/#summary
 3. Follow the pull request template and fill in detailed description of your changes.
 
 ## 9.  Discuss and Review

--- a/com.github.chollingworth.Lampray.yml
+++ b/com.github.chollingworth.Lampray.yml
@@ -1,0 +1,17 @@
+id: io.github.chollingworth.Lampray
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: /app/lampray
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+modules:
+  - name: lampray
+    buildsystem: simple
+    build-commands:
+      - echo "skipping"
+    sources:
+      - type: file
+        path: ./build/Lamp
+        dest-filename: lampray

--- a/com.github.chollingworth.Lampray.yml
+++ b/com.github.chollingworth.Lampray.yml
@@ -1,4 +1,4 @@
-id: io.github.chollingworth.Lampray
+id: com.github.chollingworth.Lampray
 runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -1,3 +1,4 @@
+
 # Building from source
 
 > Learn how to build Lampray from source. When you're finished, you'll be able to [mod your games using Lampray](./managing-mods.md).
@@ -7,7 +8,9 @@
 To clone the Lampray repository into your home directory, run the following command:
 
 ```
-git clone git@github.com:CHollingworth/Lampray.git ~
+cd ~
+git clone git@github.com:CHollingworth/Lampray.git
+cd ./Lampray
 ```
 
 ## Step 2: Install dependencies
@@ -30,13 +33,13 @@ Lampray requires the following:
 
 You can either these dependencies manually or use the included setup script. To use the setup script, run the following command:
 
-```bash
-~/Lampray/setup.sh
+```sh
+./setup.sh
 ```
 
 If your setup is successful, you'll see the following output:
 
-```bash
+```sh
 ==> 💁 [ASDF] Done ✅
 ```
 
@@ -48,7 +51,7 @@ You can build Lampray by [using the Lampray build script](#build-script-recommen
 
 To build Lampray using the included build script, run the following command:
 
-```bash
+```sh
 ~/Lampray/build.sh
 ```
 
@@ -60,7 +63,7 @@ If your build is successful, you'll see the following output:
 
 Finally, launch Lampray.
 
-```bash
+```sh
 ~/Lampray/Build/Lampray
 ```
 
@@ -68,24 +71,24 @@ Finally, launch Lampray.
 
 To generate and configure Lampray's build files manually, run the following command:
 
-```bash
+```sh
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_MAKE_PROGRAM=ninja -G Ninja -S ./ -B ./Build
 ```
 
 Open the newly created `Build` directory.
 
-```bash
+```sh
 cd Build
 ```
 
 Build the Lampray executable.
 
-```bash
+```sh
 ninja
 ```
 
 Finally, launch Lampray.
 
-```bash
+```sh
 ~/Lampray/Build/Lampray
 ```


### PR DESCRIPTION
Lampray will now build and publish flatpaks.

Furthermore to facilitate hallway testing, when you comment in a PR `/build` a PRs can have a flatpak generated as a artifact (not a release) and you'll see a comment link to the created preview flatpak.

This is useful for:

- the release PRs to get a preview of what a release is going to be like.
- fix and feature PRs: test if your changes are helpful.

## Todo

- [ ] test and ensure that the preview workflow only runs when the chatops command is used.
- [ ] rename the flatpak id for previews so it's different from the release build
- [ ] work out how publishing flatpaks work: what detaisl are required etc.

