### PR TITLE
feat: Add warning notifications when game paths are not set

### DIFF
--- a/Lampray/Control/lampNotification.h
+++ b/Lampray/Control/lampNotification.h
@@ -94,27 +94,27 @@ namespace Lamp::Core{
             }
         }
 
-        void pushInfoNotification(std::string message){
-            this->addNotification(INFO, message);
+        void pushInfoNotification(std::string message, bool oneTime = false){
+            this->addNotification(INFO, message, oneTime);
         }
-        void pushSuccessNotification(std::string message){
-            this->addNotification(SUCCESS, message);
+        void pushSuccessNotification(std::string message, bool oneTime = false){
+            this->addNotification(SUCCESS, message, oneTime);
         }
-        void pushWarningNotification(std::string message){
-            this->addNotification(WARNING, message);
+        void pushWarningNotification(std::string message, bool oneTime = false){
+            this->addNotification(WARNING, message, oneTime);
         }
-        void pushErrorNotification(std::string message){
-            this->addNotification(ERROR, message);
+        void pushErrorNotification(std::string message, bool oneTime = false){
+            this->addNotification(ERROR, message, oneTime);
         }
-        void pushNotification(std::string notiftype, std::string message){
+        void pushNotification(std::string notiftype, std::string message, bool oneTime = false){
             if(notiftype == "info"){
-                this->pushInfoNotification(message);
+                this->pushInfoNotification(message, oneTime);
             } else if(notiftype == "warning"){
-                this->pushWarningNotification(message);
+                this->pushWarningNotification(message, oneTime);
             } else if(notiftype == "error"){
-                this->pushErrorNotification(message);
+                this->pushErrorNotification(message, oneTime);
             } else if(notiftype == "success"){
-                this->pushSuccessNotification(message);
+                this->pushSuccessNotification(message, oneTime);
             } else{
                 std::cout << "Invalid notification type given: " << notiftype << "\n";
             }
@@ -144,8 +144,19 @@ namespace Lamp::Core{
 
         // array containing a vector of notifications for each type, so typeList<notificationList>
         std::array<std::vector<std::string>, NOTIFTYPE_END_PLACEHOLDER> notifications;
+        // oneTimeNotifications are notifications that should only be displayed once per session (we do not keep track between sessions)
+        std::vector<std::string> oneTimeNotifications;
 
-        void addNotification(int notiftype, std::string message){
+        void addNotification(int notiftype, std::string message, bool oneTime = false){
+            if(oneTime){
+                if((std::find(this->oneTimeNotifications.begin(), this->oneTimeNotifications.end(), message) != this->oneTimeNotifications.end())){
+                    // we have already seen this oneTime notification, so do not try to display it again
+                    return;
+                } else{
+                    this->oneTimeNotifications.push_back(message);
+                }
+            }
+
             // avoid adding duplicate notifications
             if(std::find(this->notifications[notiftype].begin(), this->notifications[notiftype].end(), message) == this->notifications[notiftype].end()){
                 this->notifications[notiftype].push_back(message);

--- a/Lampray/Lang/lampLang.h
+++ b/Lampray/Lang/lampLang.h
@@ -193,6 +193,7 @@ This action cannot be undone.)");
                 addLangNode("LAMPRAY_CUSTOM_SV", "Save");
                 addLangNode("LAMPRAY_SELECT_PATH", "Select Path");
                 addLangNode("LAMPRAY_ERROR_7Z", "Failed to find 7z.so! Many actions, such as deployment, will not function correctly. See the wiki for more information.");
+                addLangNode("LAMPRAY_WARN_GAME_PATH", " directories are not set. Deployment will not work until you have set them in the Game Configuration menu.");
                 std::filesystem::create_directories("Lamp_Language/");
                 doc.save_file("Lamp_Language/English (UK).xml");
             }

--- a/Lampray/Menu/lampMenu.cpp
+++ b/Lampray/Menu/lampMenu.cpp
@@ -124,11 +124,16 @@ void Lamp::Core::lampMenu::ModMenu() {
 
 
     if(deployCheck) {
+        if(!Lamp::Games::getInstance().currentGame->installPathSet()){
+            Lamp::Core::lampNotification::getInstance().pushNotification("warning", "Game paths not set for " + Lamp::Games::getInstance().currentGame->Ident().ReadableName);
+        }
+
         ImGuiIO &io = ImGui::GetIO();
         ImGui::SetNextWindowSize(io.DisplaySize, 0);
         ImGui::SetNextWindowPos(ImVec2(0, 0));
 
         ImGui::Begin(lampLang::LS("LAMPRAY_CHECK"), NULL, Lamp::Core::lampConfig::getInstance().DefaultWindowFlags());
+        Lamp::Core::lampNotification::getInstance().DisplayNotifications();
         ImGui::Text("%s", lampLang::LS("LAMPRAY_STARTTEXT").c_str());
 
         if(ImGui::Button(lampLang::LS("LAMPRAY_START"))){

--- a/Lampray/Menu/lampMenu.cpp
+++ b/Lampray/Menu/lampMenu.cpp
@@ -125,7 +125,7 @@ void Lamp::Core::lampMenu::ModMenu() {
 
     if(deployCheck) {
         if(!Lamp::Games::getInstance().currentGame->installPathSet()){
-            Lamp::Core::lampNotification::getInstance().pushNotification("warning", "Game paths not set for " + Lamp::Games::getInstance().currentGame->Ident().ReadableName, true);
+            Lamp::Core::lampNotification::getInstance().pushNotification("warning", Lamp::Games::getInstance().currentGame->Ident().ReadableName + Lamp::Core::lampLang::getInstance().LS("LAMPRAY_WARN_GAME_PATH"), true);
         }
 
         ImGuiIO &io = ImGui::GetIO();

--- a/Lampray/Menu/lampMenu.cpp
+++ b/Lampray/Menu/lampMenu.cpp
@@ -125,7 +125,7 @@ void Lamp::Core::lampMenu::ModMenu() {
 
     if(deployCheck) {
         if(!Lamp::Games::getInstance().currentGame->installPathSet()){
-            Lamp::Core::lampNotification::getInstance().pushNotification("warning", "Game paths not set for " + Lamp::Games::getInstance().currentGame->Ident().ReadableName);
+            Lamp::Core::lampNotification::getInstance().pushNotification("warning", "Game paths not set for " + Lamp::Games::getInstance().currentGame->Ident().ReadableName, true);
         }
 
         ImGuiIO &io = ImGui::GetIO();

--- a/game-data/BG3/BG3.h
+++ b/game-data/BG3/BG3.h
@@ -77,8 +77,7 @@ namespace Lamp::Game {
         }
 
         bool installPathSet() override{
-            // if they set the install path, assume they set the appdirpath as well...
-            if(this->KeyInfo()["installDirPath"] == ""){
+            if(this->KeyInfo()["installDirPath"] == "" || this->KeyInfo()["appDataPath"] == ""){
                 return false;
             }
             return true;

--- a/game-data/BG3/BG3.h
+++ b/game-data/BG3/BG3.h
@@ -76,6 +76,14 @@ namespace Lamp::Game {
             std::filesystem::rename(std::filesystem::path(KeyInfo()["appDataPath"]+"/Mods").parent_path() / ("Lampray Managed - " + std::filesystem::path(KeyInfo()["appDataPath"]+"/Mods").stem().string()), std::filesystem::path(KeyInfo()["appDataPath"]+"/Mods"));
         }
 
+        bool installPathSet() override{
+            // if they set the install path, assume they set the appdirpath as well...
+            if(this->KeyInfo()["installDirPath"] == ""){
+                return false;
+            }
+            return true;
+        }
+
 	private:
 
         bool skipMount = false;

--- a/game-data/C77/C77.h
+++ b/game-data/C77/C77.h
@@ -74,6 +74,13 @@ namespace Lamp::Game {
                 return ModTypeMap;
             }
 
+            bool installPathSet() override{
+                if(this->KeyInfo()["installPath"] == ""){
+                    return false;
+                }
+                return true;
+            }
+
         private:
 
             enum ModType{

--- a/game-data/gameControl.h
+++ b/game-data/gameControl.h
@@ -135,6 +135,10 @@ namespace Lamp::Game {
             return returnModTypes;
         }
 
+        /**
+         * @brief Checks if all necessary paths are configured for the given game.
+         * @return true if all necessary paths are set for this game, otherwise false.
+         */
         virtual bool installPathSet(){
             return true;
         }

--- a/game-data/gameControl.h
+++ b/game-data/gameControl.h
@@ -135,6 +135,10 @@ namespace Lamp::Game {
             return returnModTypes;
         }
 
+        virtual bool installPathSet(){
+            return true;
+        }
+
     protected:
         /**
          * @brief Protected constructor for the game control class.


### PR DESCRIPTION
This adds a warning notification when a user goes to deploy mods for a game, and the game paths are not set.

This warning will only start to show when the user has clicked the initial "Deploy" button from the mod list screen (ie, it will show when the user reaches the screen prompting to either start the deployment or go back). This notification is configured to only display once per session per game (so if a user clears it, it will not show up again until they restart Lampray).

To help enable this, this change adds a function to `gameControl` and each individual game called `installPathSet` which is meant to return true if all necessary paths are set for a game, and return false if any are not set.