### PR TITLE
feat: Add Flatpak to this project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,14 @@ ipch
 *.VC.db
 *.VC.VC.opendb
 
+## Visual Studio Code artifacts
+.vscode
+
+## Flatpak artifacts
+*.flatpak-builder
+
 ## Commonly used CMake directories
-build*/
+build/
 
 ## Xcode artifacts
 project.xcworkspace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@ project(Lampray)
 
 set(CMAKE_CXX_STANDARD 17)
 
-
-
-
 add_executable(Lampray main.cpp
         third-party/imgui/imconfig.h
         third-party/imgui/imgui.cpp
@@ -50,9 +47,6 @@ add_executable(Lampray main.cpp
         Lampray/Lang/lampLang.h
 )
 
-
-
-
 find_package(PkgConfig REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/third-party/bit7z/lib/x64/libbit7z64.a )
@@ -60,7 +54,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/third-part
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/third-party/nfd/lib/libnfd.a )
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/third-party/nfd/include/include/nfd.h )
-
 
 # Find the SDL2 package
 find_package(SDL2 REQUIRED)
@@ -82,7 +75,5 @@ find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${CURL_LIBRARIES})
 
-
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/third-party/l4z/liblz4.so)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/third-party/l4z/)
-

--- a/Lampray/Control/lampConfig.cpp
+++ b/Lampray/Control/lampConfig.cpp
@@ -5,25 +5,27 @@
 #include "../Filesystem/lampFS.h"
 
 bool Lamp::Core::lampConfig::init() {
-        Base::lampLog::getInstance().log("Initializing Lampray");
+    Base::lampLog::getInstance().log("Initializing Lampray");
 
-        if((std::string)bit7zLibaryLocation == "") {
-            Base::lampLog::getInstance().log("Searching for 7z.so");
-            std::filesystem::path f{"/usr/libexec/p7zip/7z.so"};
-            if (std::filesystem::exists(f)) {
-                bit7zLibaryLocation = "/usr/libexec/p7zip/7z.so";
-            } else if (exists(std::filesystem::path{"/usr/lib/p7zip/7z.so"})) {
-                bit7zLibaryLocation = "/usr/lib/p7zip/7z.so";
-            } else if (exists(std::filesystem::path{"/usr/lib64/p7zip/7z.so"})) {
-                bit7zLibaryLocation = "/usr/lib64/p7zip/7z.so";
-            } else if (exists(std::filesystem::path{"/usr/libexec/7z.so"})) {
-                bit7zLibaryLocation = "/usr/libexec/7z.so";
-            } else {
-                Base::lampLog::getInstance().log("Fatal. Cannot locate 7z.so", Base::lampLog::ERROR, true,
-                                                 Base::lampLog::LMP_NO7ZP);
-                return false;
-            }
+    if((std::string)bit7zLibaryLocation == "") {
+        Base::lampLog::getInstance().log("Searching for 7z.so");
+        std::filesystem::path f{"/usr/libexec/p7zip/7z.so"};
+        if (std::filesystem::exists(f)) {
+            bit7zLibaryLocation = "/usr/libexec/p7zip/7z.so";
+        } else if (exists(std::filesystem::path{"/usr/lib/p7zip/7z.so"})) {
+            bit7zLibaryLocation = "/usr/lib/p7zip/7z.so";
+        } else if (exists(std::filesystem::path{"/usr/lib64/p7zip/7z.so"})) {
+            bit7zLibaryLocation = "/usr/lib64/p7zip/7z.so";
+        } else if (exists(std::filesystem::path{"/usr/libexec/7z.so"})) {
+            bit7zLibaryLocation = "/usr/libexec/7z.so";
+        } else if (exists(std::filesystem::path{"/app/p7zip/7z.so"})) {
+            bit7zLibaryLocation = "/app/p7zip/7z.so";
+        } else {
+            Base::lampLog::getInstance().log("Fatal. Cannot locate 7z.so", Base::lampLog::ERROR, true,
+                                             Base::lampLog::LMP_NO7ZP);
+            return false;
         }
+    }
 
     return true;
 }

--- a/build-aux/README.md
+++ b/build-aux/README.md
@@ -1,0 +1,21 @@
+# `build-aux` folder
+
+This folder contains:
+- The Flatpak manifest used to build Lampray
+
+## OBS Studio Flatpak Manifest
+
+The manifest is composed of multiple files:
+ - The main manifest `com.github.chollingworth.Lampray.yml`
+ - The `modules` folder which contains OBS Studio dependencies modules
+
+### Manifest modules
+
+Modules are ordered/dispatched in numbered categories following a short list of rules:
+- A module must not depend on another module from the same category, so a module can only depend on modules from lower numbered categories.
+- A module without dependencies must be placed in the highest numbered category in use, excluding categories meant for specific types of dependency.
+
+Actual categories:
+ - `90-`: Headers-only libraries that are dependencies of only Lampray
+ - `50-`: Modules that are dependencies of only Lamprey
+ - `40-`: Modules that are dependencies of the `50-` category

--- a/build-aux/com.github.chollingworth.Lampray.yml
+++ b/build-aux/com.github.chollingworth.Lampray.yml
@@ -21,6 +21,7 @@ cleanup:
   - "/app/*"
   - "!/app/src" # Don't remove the source code
   - "!/app/bin/Lampray" # Don't remove the built binary
+  - "!/app/p7zip" # Don't remove the p7zip directory
 modules:
   - name: Lampray
     buildsystem: cmake-ninja
@@ -34,3 +35,4 @@ modules:
     sources:
       - type: dir
         path: "../"
+  - "modules/50-p7zip.yml"

--- a/build-aux/com.github.chollingworth.Lampray.yml
+++ b/build-aux/com.github.chollingworth.Lampray.yml
@@ -1,0 +1,31 @@
+app-id: com.github.chollingworth.Lampray
+runtime: org.freedesktop.Platform
+runtime-version: "23.08"
+sdk: org.freedesktop.Sdk
+command: Lampray
+only-arches:
+  - x86_64 # Only build for x86_64
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11 # Enable X11 support
+  - --device=dri
+  - --filesystem=host
+build-options:
+  env:
+    V: "1" # Enable verbose build output for all build systems
+  arch:
+    x86_64:
+      cflags: "-O3 -g" # Use -O3 for x86_64 builds
+modules:
+  - name: Lampray
+    buildsystem: cmake-ninja
+    builddir: true
+    build-commands:
+      - install -D Lampray /app/bin/Lampray
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Debug
+      - -DCMAKE_MAKE_PROGRAM=ninja
+    sources:
+      - type: dir
+        path: "../"

--- a/build-aux/com.github.chollingworth.Lampray.yml
+++ b/build-aux/com.github.chollingworth.Lampray.yml
@@ -17,11 +17,16 @@ build-options:
   arch:
     x86_64:
       cflags: "-O3 -g" # Use -O3 for x86_64 builds
+cleanup:
+  - "/app/*"
+  - "!/app/src" # Don't remove the source code
+  - "!/app/bin/Lampray" # Don't remove the built binary
 modules:
   - name: Lampray
     buildsystem: cmake-ninja
     builddir: true
     build-commands:
+      - cp -r . /app/src # Copy the source code to the build directory
       - install -D Lampray /app/bin/Lampray
     config-opts:
       - -DCMAKE_BUILD_TYPE=Debug

--- a/build-aux/modules/50-p7zip.yml
+++ b/build-aux/modules/50-p7zip.yml
@@ -1,0 +1,12 @@
+name: p7zip
+buildsystem: simple
+build-commands:
+  - install -d /app/p7zip
+  - unzip linux-cmake-p7zip.zip -d /app/p7zip
+cleanup:
+  - "*"
+sources:
+  - type: archive
+    url: https://github.com/p7zip-project/p7zip/releases/download/v17.05/linux-cmake-p7zip.zip
+    sha256: 5c14a69015342c0724bfa2c6937dea1989858c29dc725b8c2fbe2ef0f584e0a7
+    dest: .

--- a/build-aux/modules/50-p7zip.yml
+++ b/build-aux/modules/50-p7zip.yml
@@ -2,11 +2,11 @@ name: p7zip
 buildsystem: simple
 build-commands:
   - install -d /app/p7zip
-  - unzip linux-cmake-p7zip.zip -d /app/p7zip
+  - mv ${FLATPAK_BUILDER_BUILDDIR}/* /app/p7zip
+  - ls -la /app/p7zip
 cleanup:
-  - "*"
+  - "!/app/p7zip/*"
 sources:
   - type: archive
     url: https://github.com/p7zip-project/p7zip/releases/download/v17.05/linux-cmake-p7zip.zip
-    sha256: 5c14a69015342c0724bfa2c6937dea1989858c29dc725b8c2fbe2ef0f584e0a7
-    dest: .
+    sha256: ac5240801ef208b7e7018a353c0d699526f5a0367fb8be89ce89a7b2cafb7d4e

--- a/build-flatpak.sh
+++ b/build-flatpak.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Build and install the Flatpak
+flatpak-builder --force-clean --user --install build-dir build-aux/com.github.chollingworth.Lampray.yml
+
+# Run the Flatpak
+flatpak run --user com.github.chollingworth.Lampray


### PR DESCRIPTION
Hello again,

I managed to introduce Flatpak support to this project. You can test and debug things using the `build-flatpak.sh` file, as requested in VC by @airtonix. This project fully builds the flatpak and is now entirely self-contained.

The name has been changed to `com.github.chollingworth.Lampray.yml` for the very same reason as above. In the next phase, this will be built using a CI/CD GitHub pipeline made by @airtonix.

I have used the [OBS Flatpak manifests](https://github.com/obsproject/obs-studio/tree/b45a73296f4f898e2ed455023020058075c30bab/build-aux) as a muse for my flatpak build system, which was heavily recommended to me.

Please remember that every so often before an official update, we should bump up the version in `50-p7zip.yml`.

I would like to take this opportunity to ask for the merge of #122 to this branch of the repository instead of main, if agreed.


P.s.
I have 3 hours of sleep in me, I did 2 exams today at the uni and it's 03:05 AM. My body is moving on coffee alone.

I am wishing you all goodnight, please do contact me on Discord if you want to coordinate for the next phases or you want me to screenshare and explain things. I will be glad, but now I need to sleep 💤 