### PR TITLE
feat: Include the current Lampray version in the log for debugging

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,7 @@ int main(int, char**)
     file.close();
 
     Lamp::Core::Base::lampLog::getInstance().log(Lamp::Core::lampControl::getFormattedTimeAndDate()+" | | Battle Control Online, Welcome Back Commander.", Lamp::Core::Base::lampLog::LOG);
+    Lamp::Core::Base::lampLog::getInstance().log("Lampray version: " + Lamp::Core::FS::lampUpdate::getInstance().versionNumber);
 
     Lamp::Games::getInstance();
 


### PR DESCRIPTION
Add a line near the beginning of the log file, and in the output, containing the current Lampray version string (pulled from `Lampray/Filesystem/lampFS.h`).

This should be helpful in determining if a reported issue is from a current or outdated version of Lampray.