### PR TITLE
feat: Re-enable rar support

### DIFF
--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -27,13 +27,16 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
                                                      true, Base::lampLog::LMP_EXTRACTIONFALED);
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(rar)$"))) {
-
-        // Rar Extraction Goes Here!
-
-        //[mod->ArchivePath] Path to the archive to extract
-
-        //[workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()] Folder path for files to extract to.
-
+        try {
+            bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
+            bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+            reader.test();
+            reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
+            return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
+        } catch (const bit7z::BitException &ex) {
+            return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath},  Base::lampLog::ERROR,
+                                                     true, Base::lampLog::LMP_EXTRACTIONFALED);
+        }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {
             bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -29,13 +29,21 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(rar)$"))) {
         try {
             bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
-            bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+            bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar5};
             reader.test();
             reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
             return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
         } catch (const bit7z::BitException &ex) {
-            return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath},  Base::lampLog::ERROR,
-                                                     true, Base::lampLog::LMP_EXTRACTIONFALED);
+            try {
+                bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
+                bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+                reader.test();
+                reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
+                return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
+            } catch (const bit7z::BitException &ex2) {
+                return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath + "\nMessages:\n" + ex.what() + "\n" + ex2.what()},
+                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+            }
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {

--- a/Lampray/Filesystem/lampIO.cpp
+++ b/Lampray/Filesystem/lampIO.cpp
@@ -192,9 +192,7 @@ void Lamp::Core::FS::lampIO::fileDrop(const char *inputPath) {
         std::filesystem::path path(inputPath);
         std::error_code ec;
         if (std::filesystem::is_regular_file(path, ec)) {
-            // Reenable rar support here.
-            //if (std::regex_match(path.filename().string(), std::regex("^.*\\.(zip|rar|7z)$"))) {
-            if (std::regex_match(path.filename().string(), std::regex("^.*\\.(zip|7z)$"))) {
+            if (std::regex_match(path.filename().string(), std::regex("^.*\\.(zip|rar|7z)$"))) {
                 std::filesystem::path targetDIR = Core::lampConfig::getInstance().archiveDataPath +
                         Lamp::Games::getInstance().currentGame->Ident().ReadableName; // Roi Danton many thanks again!
                 auto target = targetDIR / path.filename();


### PR DESCRIPTION
This re-enables attempted support for .rar files. It will attempt to decompress with Rar5 first, and fallback to the older Rar method if that fails.

If both methods fail, the user will get an error notification with the error messages from both attempts.

I tested with the main .rar files from <https://github.com/ssokolow/rar-test-files>. This successfully extracted the `testfile.rar5.rar` file, but still fails on the `testfile.rar3.rar` file, so support will probably still be spotty.