### PR TITLE
feat: Utilize Unrar for rar support if it is installed

### DIFF
--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -27,23 +27,34 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
                                                      true, Base::lampLog::LMP_EXTRACTIONFALED);
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(rar)$"))) {
-        try {
-            bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
-            bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar5};
-            reader.test();
-            reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
-            return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
-        } catch (const bit7z::BitException &ex) {
+        // check if the user has unrar so we can try using that instead
+        if (system("which unrar > /dev/null 2>&1")) {
+            // Command doesn't exist, try using bit7z
             try {
                 bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
-                bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+                bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar5};
                 reader.test();
                 reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
                 return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
-            } catch (const bit7z::BitException &ex2) {
-                return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath + "\nMessages:\n" + ex.what() + "\n" + ex2.what()},
-                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+            } catch (const bit7z::BitException &ex) {
+                // try using an alternate Rar format
+                try {
+                    bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
+                    bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+                    reader.test();
+                    reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
+                    return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
+                } catch (const bit7z::BitException &ex2) {
+                    return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath + "\nMessages:\n" + ex.what() + "\n" + ex2.what()},
+                                                            Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+                }
             }
+        } else {
+            // unrar seems to exist, so use it instead
+            auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
+            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"";
+            //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
+            system(unrar_cmd_string.c_str());
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -53,7 +53,6 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             // unrar seems to exist, so use it instead
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
             auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
-            //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
             int result = system(unrar_cmd_string.c_str());
             if(result == 0){
                 return Base::lampLog::getInstance().pLog({1, "Extraction Successful with unrar : " + mod->ArchivePath},  Base::lampLog::LOG);

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -52,7 +52,7 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
         } else {
             // unrar seems to exist, so use it instead
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
-            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"";
+            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
             //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
             system(unrar_cmd_string.c_str());
         }

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -54,7 +54,13 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
             auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
             //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
-            system(unrar_cmd_string.c_str());
+            int result = system(unrar_cmd_string.c_str());
+            if(result == 0){
+                return Base::lampLog::getInstance().pLog({1, "Extraction Successful with unrar : " + mod->ArchivePath},  Base::lampLog::LOG);
+            } else{
+                return Base::lampLog::getInstance().pLog({0, "Could not extract file with unrar : " + mod->ArchivePath},
+                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+            }
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now you're ready to [mod your game](./docs/managing-mods.md).
 
 ### Currently supported
 
-> **Note:** At this time, mods using `.rar` files are not supported.
+> **Note:** At this time, mods using `.rar` files have limited support. For best results, install unrar.
 
 - Baldur's Gate 3
 - Cyberpunk 2077


### PR DESCRIPTION
This changes the handling of extracting .rar files to first check if the `unrar` command is available. If it is, this then uses `unrar` to extract .rar files, otherwise it uses the previous bit7z methods.

This should enable much better support for .rar files through unrar for users who wish to install (or already have installed) `unrar`.