### PR TITLE
feat: Attempt to utilize external applications for rar  extract support

### DIFF
--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -31,8 +31,8 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
         auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
 
         if(!system("which 7z > /dev/null 2>&1")) {
-            auto unrar_cmd_string = "7z e \"" + (std::string)mod->ArchivePath + "\" -o\""+rar_base_out+"\"  > /dev/null 2>&1";
-            int result = system(unrar_cmd_string.c_str());
+            auto sevenz_cmd_string = "7z e \"" + (std::string)mod->ArchivePath + "\" -o\""+rar_base_out+"\"  > /dev/null 2>&1";
+            int result = system(sevenz_cmd_string.c_str());
 
             if(result == 0){
                 return Base::lampLog::getInstance().pLog({1, "Extraction Successful with 7z : " + mod->ArchivePath},  Base::lampLog::LOG);

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -39,7 +39,7 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             } else{
                 // do not return so we can attempt the next method as well
                 Base::lampLog::getInstance().pLog({0, "Could not extract file with 7z : " + mod->ArchivePath},
-                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+                                                     Base::lampLog::ERROR, false, Base::lampLog::LMP_EXTRACTIONFALED);
             }
         }
 
@@ -51,7 +51,7 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             } else{
                 // do not return so we can attempt the next method as well
                 Base::lampLog::getInstance().pLog({0, "Could not extract file with unrar : " + mod->ArchivePath},
-                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+                                                     Base::lampLog::ERROR, false, Base::lampLog::LMP_EXTRACTIONFALED);
             }
         }
 

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -27,23 +27,34 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
                                                      true, Base::lampLog::LMP_EXTRACTIONFALED);
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(rar)$"))) {
-        try {
-            bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
-            bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar5};
-            reader.test();
-            reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
-            return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
-        } catch (const bit7z::BitException &ex) {
+        // check if the user has unrar so we can try using that instead
+        if (system("which unrar > /dev/null 2>&1")) {
+            // Command doesn't exist, try using bit7z
             try {
                 bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
-                bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+                bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar5};
                 reader.test();
                 reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
                 return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
-            } catch (const bit7z::BitException &ex2) {
-                return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath + "\nMessages:\n" + ex.what() + "\n" + ex2.what()},
-                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+            } catch (const bit7z::BitException &ex) {
+                // try using an alternate Rar format
+                try {
+                    bit7z::Bit7zLibrary lib{Lamp::Core::lampConfig::getInstance().bit7zLibaryLocation};
+                    bit7z::BitArchiveReader reader{lib, mod->ArchivePath, bit7z::BitFormat::Rar};
+                    reader.test();
+                    reader.extract(workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string());
+                    return Base::lampLog::getInstance().pLog({1, "Extraction Successful. : "+ mod->ArchivePath},  Base::lampLog::LOG);
+                } catch (const bit7z::BitException &ex2) {
+                    return Base::lampLog::getInstance().pLog({0, "Could not extract file : "+ mod->ArchivePath + "\nMessages:\n" + ex.what() + "\n" + ex2.what()},
+                                                            Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+                }
             }
+        } else {
+            // unrar seems to exist, so use it instead
+            auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
+            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"";
+            //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
+            system(unrar_cmd_string.c_str());
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -53,7 +53,6 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             // unrar seems to exist, so use it instead
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
             auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
-            //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
             int result = system(unrar_cmd_string.c_str());
             if(result == 0){
                 return Base::lampLog::getInstance().pLog({1, "Extraction Successful with unrar : " + mod->ArchivePath},  Base::lampLog::LOG);

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -52,7 +52,7 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
         } else {
             // unrar seems to exist, so use it instead
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
-            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"";
+            auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
             //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
             system(unrar_cmd_string.c_str());
         }

--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -54,7 +54,13 @@ Lamp::Core::FS::lampReturn Lamp::Core::FS::lampExtract::extract(const Base::lamp
             auto rar_base_out = workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string();
             auto unrar_cmd_string = "unrar e \"" + (std::string)mod->ArchivePath + "\" \""+rar_base_out+"\"  > /dev/null 2>&1";
             //system(("unrar e \"" + (std::string)mod->ArchivePath + "\" \""+workingDir + "/ext/" + std::filesystem::path(mod->ArchivePath).filename().stem().string()+"\"").c_str());
-            system(unrar_cmd_string.c_str());
+            int result = system(unrar_cmd_string.c_str());
+            if(result == 0){
+                return Base::lampLog::getInstance().pLog({1, "Extraction Successful with unrar : " + mod->ArchivePath},  Base::lampLog::LOG);
+            } else{
+                return Base::lampLog::getInstance().pLog({0, "Could not extract file with unrar : " + mod->ArchivePath},
+                                                     Base::lampLog::ERROR, true, Base::lampLog::LMP_EXTRACTIONFALED);
+            }
         }
     } else if (std::regex_match((std::string)mod->ArchivePath, std::regex("^.*\\.(7z)$"))) {
         try {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now you're ready to [mod your game](./docs/managing-mods.md).
 
 ### Currently supported
 
-> **Note:** At this time, mods using `.rar` files are not supported.
+> **Note:** At this time, mods using `.rar` files have limited support. For best results, install unrar.
 
 - Baldur's Gate 3
 - Cyberpunk 2077


### PR DESCRIPTION
This is likely a slightly better solution for `.rar` support than #146. The main difference is that this first attempts to utilize the `7z` command, which has likely been installed by the user as part of the listed `7-Zip` dependency. It will also continue trying the other methods, instead of stopping at the first failure.

This change attempts to extract `.rar` files in this order:
1. The `7z` command
2. The `unrar` command
3. The original `bit7z` method.

On my system, the `7z` command was able to extract the `.rar` test files I have without issue, but this support may depend on what version of `7z` users install.