### PR TITLE
fix: Create the directory before you begin trying to copy files to it

### DIFF
--- a/Lampray/Filesystem/lampExtract.cpp
+++ b/Lampray/Filesystem/lampExtract.cpp
@@ -128,6 +128,7 @@ Lamp::Core::lampReturn Lamp::Core::FS::lampExtract::caseInsensitiveFolderCopyRec
     for (const auto& entry : fs::recursive_directory_iterator(sourceDirectory)) {
         if (fs::is_directory(entry) &&
             caseInsensitiveStringCompare(entry.path().filename().string(), targetDirectoryName)) {
+            fs::create_directories(destinationDirectory);
             lampReturn result = copyDirectoryRecursively(entry, destinationDirectory);
             if (!result) {
                 return result; // Propagate the error if copying failed


### PR DESCRIPTION
There's a current issue with the copy functionality where if the first entry in a directory is a file, the root directory doesn't get made, so the file copy fails. This is commonly seen installing RED4ext for CP2077.

The problematic archive format

```
RED4ext.zip
|--bin
|   |--x64
|       |--winmm.dll
|
|--red4ext
    |--plugins
    |   |--[EMPTY]
    |--LICENSE.txt
    |--RED4ext.dll
    |--THIRD_PARTY_LICENSES.txt
``` 
In the current functionality, when Lampray tries to copy the red4ext folder over, the first entry it gets is Deployment/Cyberpunk 2077/ext/[archive]/red4ext/LICENSE.txt. It tries to copy it into Deployment/Cyberpunk 2077/Cyberpunk 2777/red4ext/LICENSE.txt where it belongs. However, it does this before the Deployment/Cyberpunk 2077/Cyberpunk 2777/red4ext folder is ever made, meaning the copy fails. This leads to the more important RED4ext.dll never being copyed over.

I've updated the code that before it begins to copy the folder recursively, it creates the destination directory. This happens before any file copies, meaning the destination will now always be there

I've tested this with CP2077 to success. I currently cant test it with BG3, but I dont see it causing any issues there personally